### PR TITLE
Enforce VLAN assignments based on unit name

### DIFF
--- a/cosmo/routervisitor.py
+++ b/cosmo/routervisitor.py
@@ -208,6 +208,9 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor):
                         }
                     }
                 }
+            # sub-interface but not .0, enforce numbering conventions
+            elif o.getUnitNumber() != o.getUntaggedVLAN().getVID():
+                warn(f"sub-interface number should be same as VLAN ({o.getUntaggedVLAN().getVID()})", o)
         return deepmerge.always_merger.merge({
             self._interfaces_key: {
                 **o.spitInterfacePathWith({
@@ -362,6 +365,9 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor):
                         }
                     }
                 }
+            # sub-interface but not .0, enforce numbering conventions
+            elif parent_interface.getUnitNumber() != o.getVID():
+                warn(f"sub-interface number should be same as VLAN ({o.getVID()})", parent_interface)
             return deepmerge.always_merger.merge({
                 self._interfaces_key: {
                     **parent_interface.spitInterfacePathWith({

--- a/cosmo/tests/test_case_2.yaml
+++ b/cosmo/tests/test_case_2.yaml
@@ -56,6 +56,54 @@ device_list:
       storm_control__broadcast: null
       storm_control__multicast: null
       storm_control__unknown_unicast: null
+    description: 'Customer: incorrectly numbered sub-interface with VLAN'
+    __typename: InterfaceType
+    enabled: true
+    id: '189032'
+    ip_addresses: []
+    lag: null
+    mac_address: null
+    mode: ACCESS
+    mtu: null
+    name: et-0/0/0.1
+    tagged_vlans: []
+    tags: [ ]
+    type: VIRTUAL
+    untagged_vlan:
+      __typename: VLANType
+      id: '823746'
+      name: TEST-VLAN-123
+      vid: 123
+    vrf: null
+  - custom_fields:
+      bpdufilter: false
+      inner_tag: null
+      outer_tag: 456
+      storm_control__broadcast: null
+      storm_control__multicast: null
+      storm_control__unknown_unicast: null
+    description: 'Customer: incorrectly numbered sub-interface with outer_tag'
+    __typename: InterfaceType
+    enabled: true
+    id: '189033'
+    ip_addresses: []
+    lag: null
+    mac_address: null
+    mode: ACCESS
+    mtu: null
+    name: et-0/0/0.2
+    tagged_vlans: []
+    tags: [ ]
+    type: VIRTUAL
+    untagged_vlan: null
+    vrf: null
+  - custom_fields:
+      bpdufilter: false
+      inner_tag: null
+      outer_tag: null
+      storm_control__broadcast: null
+      storm_control__multicast: null
+      storm_control__unknown_unicast: null
     description: 'Customer: Test-VLAN'
     __typename: InterfaceType
     enabled: true

--- a/cosmo/tests/test_serializer.py
+++ b/cosmo/tests/test_serializer.py
@@ -170,13 +170,16 @@ def test_router_physical_interface():
     assert sd['interfaces']['et-0/0/3']['breakout'] == '4x10g'
 
 
-def test_router_logical_interface():
+def test_router_logical_interface(capsys):
     [sd] = get_router_sd_from_path("./test_case_2.yaml")
 
-    assert len(sd['interfaces']['et-0/0/0']['units']) == 2
+    assert len(sd['interfaces']['et-0/0/0']['units']) == 4
 
     assert 139 in sd['interfaces']['et-0/0/0']['units']
     assert 150 in sd['interfaces']['et-0/0/0']['units']
+    assert 1 in sd['interfaces']['et-0/0/0']['units']
+    assert 2 in sd['interfaces']['et-0/0/0']['units']
+
     # should be present but shut down
     assert sd['interfaces']['et-0/0/0']['units'][150]['shutdown']
 
@@ -184,6 +187,11 @@ def test_router_logical_interface():
 
     assert "Customer: Test-VLAN" == unit['description']
     assert 139 == unit['vlan']
+
+    # we should have a warning for #1 and #2, which do not respect numbering conventions
+    output = capsys.readouterr()
+    assert re.search(r"0.1] sub-interface number should be same as VLAN \(123\)", output.out)
+    assert re.search(r"0.2] sub-interface number should be same as VLAN \(456\)", output.out)
 
 
 def test_router_lag():


### PR DESCRIPTION
fixes #18 

I have chosen to issue a warning, IMO this should not stop the device from being exported. What do you think?