### PR TITLE
remove serial from output

### DIFF
--- a/cosmo/clients/netbox_v4.py
+++ b/cosmo/clients/netbox_v4.py
@@ -427,7 +427,6 @@ class DeviceDataQuery(ParallelQuery):
                 __typename
                 id
                 name
-                serial
                 custom_fields
 
                 device_type {

--- a/cosmo/netbox_types.py
+++ b/cosmo/netbox_types.py
@@ -280,9 +280,6 @@ class DeviceType(AbstractNetboxType):
     def getInterfaces(self) -> list["InterfaceType"]:
         return self.get("interfaces", [])
 
-    def getSerial(self) -> str:
-        return self.get("serial", "")
-
     def getISISIdentifier(self) -> str | None | Never:
         sys_id: Any | None = self.getCustomFields().get("isis_system_id")
         if sys_id and not re.match(r"\d{4}.\d{4}.\d{4}", str(sys_id)):

--- a/cosmo/routervisitor.py
+++ b/cosmo/routervisitor.py
@@ -85,7 +85,6 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor, TVRFHelpers):
         if isis_system_id := o.getISISIdentifier():
             isis["isis"] = {"system_id": isis_system_id}
         return {
-            "serial": o.getSerial(),
             **isis,
             self._vrf_key: {
                 manufacturer.getRoutingInstanceName(): {

--- a/cosmo/tests/test_case_1.yaml
+++ b/cosmo/tests/test_case_1.yaml
@@ -61,8 +61,7 @@ device_list:
   primary_ip4:
     __typename: IPAddressType
     address: 45.139.136.10/32
-  serial: 4242
-  staticroute_set: []
+    staticroute_set: []
 l2vpn_list: []
 loopbacks:
   TEST0001:

--- a/cosmo/tests/test_case_2.yaml
+++ b/cosmo/tests/test_case_2.yaml
@@ -133,7 +133,6 @@ device_list:
   primary_ip4:
     __typename: IPAddressType
     address: 45.139.136.10/32
-  serial: 4242
   staticroute_set: []
 l2vpn_list: []
 loopbacks:

--- a/cosmo/tests/test_case_auto_descriptions.yaml
+++ b/cosmo/tests/test_case_auto_descriptions.yaml
@@ -301,7 +301,6 @@ device_list:
   primary_ip4:
     __typename: IPAddressType
     address: 45.139.136.10/32
-  serial: 4242
   staticroute_set: []
 l2vpn_list: []
 loopbacks:

--- a/cosmo/tests/test_case_bgpcpe.yml
+++ b/cosmo/tests/test_case_bgpcpe.yml
@@ -331,7 +331,6 @@ device_list:
   primary_ip4:
     __typename: IPAddressType
     address: 198.51.100.15/24
-  serial: ''
   staticroute_set: []
 l2vpn_list: []
 loopbacks:

--- a/cosmo/tests/test_case_bgpcpe_forbidden.yml
+++ b/cosmo/tests/test_case_bgpcpe_forbidden.yml
@@ -157,7 +157,6 @@ device_list:
   primary_ip4:
     __typename: IPAddressType
     address: 198.51.100.15/24
-  serial: ''
   staticroute_set: []
 l2vpn_list: []
 loopbacks:

--- a/cosmo/tests/test_case_fec.yaml
+++ b/cosmo/tests/test_case_fec.yaml
@@ -78,7 +78,6 @@ device_list:
     primary_ip4:
       __typename: IPAddressType
       address: 45.139.136.10/32
-    serial: 4242
     staticroute_set: [ ]
 l2vpn_list: [ ]
 loopbacks:

--- a/cosmo/tests/test_case_ips.yaml
+++ b/cosmo/tests/test_case_ips.yaml
@@ -104,7 +104,6 @@ device_list:
     primary_ip4:
       __typename: IPAddressType
       address: 45.139.136.10/32
-    serial: 4242
     staticroute_set: [ ]
 l2vpn_list: [ ]
 loopbacks:

--- a/cosmo/tests/test_case_isis.yaml
+++ b/cosmo/tests/test_case_isis.yaml
@@ -61,7 +61,6 @@ device_list:
   primary_ip4:
     __typename: IPAddressType
     address: 45.139.136.10/32
-  serial: 4242
   staticroute_set: []
   custom_fields:
     isis_system_id: "0000.1234.0010"

--- a/cosmo/tests/test_case_isis_errors.yaml
+++ b/cosmo/tests/test_case_isis_errors.yaml
@@ -61,7 +61,6 @@ device_list:
   primary_ip4:
     __typename: IPAddressType
     address: 45.139.136.10/32
-  serial: 4242
   staticroute_set: []
   custom_fields:
     isis_system_id: "invalid_system_id"

--- a/cosmo/tests/test_case_l2x_err_template.yaml
+++ b/cosmo/tests/test_case_l2x_err_template.yaml
@@ -15,7 +15,6 @@ device_list:
   primary_ip4:
     __typename: IPAddressType
     address: 198.51.100.15/24
-  serial: ''
   staticroute_set: []
 l2vpn_list: []
 loopbacks:

--- a/cosmo/tests/test_case_l3vpn.yml
+++ b/cosmo/tests/test_case_l3vpn.yml
@@ -120,7 +120,6 @@ device_list:
   primary_ip4:
     address: 198.51.100.15/24
     __typename: IPAddressType
-  serial: ''
   staticroute_set: []
 l2vpn_list: []
 # This has some double use and gets put into NetboxClient and RouterSerializer.

--- a/cosmo/tests/test_case_lag.yaml
+++ b/cosmo/tests/test_case_lag.yaml
@@ -79,7 +79,6 @@ device_list:
     primary_ip4:
       __typename: IPAddressType
       address: 45.139.136.10/32
-    serial: 4242
     staticroute_set: [ ]
 l2vpn_list: [ ]
 loopbacks:

--- a/cosmo/tests/test_case_local_l2x.yaml
+++ b/cosmo/tests/test_case_local_l2x.yaml
@@ -97,7 +97,6 @@ device_list:
   primary_ip4:
     __typename: IPAddressType
     address: 198.51.100.15/24
-  serial: ''
   staticroute_set: []
 l2vpn_list:
 - id: '53'

--- a/cosmo/tests/test_case_mpls_evpn.yaml
+++ b/cosmo/tests/test_case_mpls_evpn.yaml
@@ -105,7 +105,6 @@ device_list:
   primary_ip4:
     __typename: IPAddressType
     address: 45.139.136.11/32
-  serial: CT702
   staticroute_set: []
 - device_type:
     __typename: DeviceTypeType
@@ -213,7 +212,6 @@ device_list:
   primary_ip4:
     __typename: IPAddressType
     address: 45.139.136.10/32
-  serial: ''
   staticroute_set: []
 l2vpn_list:
 - id: '34'

--- a/cosmo/tests/test_case_mtu_junos.yaml
+++ b/cosmo/tests/test_case_mtu_junos.yaml
@@ -100,7 +100,6 @@ device_list:
   primary_ip4:
     __typename: IPAddressType
     address: 45.139.136.10/32
-  serial: 4242
   staticroute_set: []
 l2vpn_list: []
 loopbacks:

--- a/cosmo/tests/test_case_mtu_rtbrick.yaml
+++ b/cosmo/tests/test_case_mtu_rtbrick.yaml
@@ -56,7 +56,6 @@ device_list:
   primary_ip4:
     __typename: IPAddressType
     address: 45.139.136.10/32
-  serial: 4242
   staticroute_set: []
 l2vpn_list: []
 loopbacks:

--- a/cosmo/tests/test_case_no_manuf_slug.yaml
+++ b/cosmo/tests/test_case_no_manuf_slug.yaml
@@ -10,6 +10,5 @@ device_list:
     raw: coyote-0-2-1-rc1
   primary_ip4:
     address: 45.139.136.10/32
-  serial: 4242
   staticroute_set: []
 l2vpn_list: []

--- a/cosmo/tests/test_case_policer.yaml
+++ b/cosmo/tests/test_case_policer.yaml
@@ -190,7 +190,6 @@ device_list:
   primary_ip4:
     address: 198.51.100.15/24
     __typename: IPAddressType
-  serial: ''
   staticroute_set: []
 l2vpn_list: []
 loopbacks:

--- a/cosmo/tests/test_case_switch_auto_description.yaml
+++ b/cosmo/tests/test_case_switch_auto_description.yaml
@@ -189,6 +189,5 @@ device_list:
   primary_ip4:
     __typename: IPAddressType
     address: 10.120.142.11/24
-  serial: 4242
   staticroute_set: []
 l2vpn_list: []

--- a/cosmo/tests/test_case_switch_fec.yaml
+++ b/cosmo/tests/test_case_switch_fec.yaml
@@ -98,6 +98,5 @@ device_list:
   primary_ip4:
     address: 10.120.142.11/24
     __typename: IPAddressType
-  serial: 4242
   staticroute_set: []
 l2vpn_list: []

--- a/cosmo/tests/test_case_switch_interface_speed.yaml
+++ b/cosmo/tests/test_case_switch_interface_speed.yaml
@@ -99,6 +99,5 @@ device_list:
   primary_ip4:
     address: 10.120.142.11/24
     __typename: IPAddressType
-  serial: 4242
   staticroute_set: []
 l2vpn_list: []

--- a/cosmo/tests/test_case_switch_lag.yaml
+++ b/cosmo/tests/test_case_switch_lag.yaml
@@ -79,6 +79,5 @@ device_list:
   primary_ip4:
     __typename: IPAddressType
     address: 10.120.142.11/24
-  serial: 4242
   staticroute_set: []
 l2vpn_list: []

--- a/cosmo/tests/test_case_switch_lldp.yaml
+++ b/cosmo/tests/test_case_switch_lldp.yaml
@@ -37,6 +37,5 @@ device_list:
   primary_ip4:
     __typename: IPAddressType
     address: 10.120.142.11/24
-  serial: 4242
   staticroute_set: []
 l2vpn_list: []

--- a/cosmo/tests/test_case_switch_mgmt.yaml
+++ b/cosmo/tests/test_case_switch_mgmt.yaml
@@ -53,6 +53,5 @@ device_list:
   primary_ip4:
     __typename: IPAddressType
     address: 10.120.142.11/24
-  serial: 4242
   staticroute_set: []
 l2vpn_list: []

--- a/cosmo/tests/test_case_switch_vlan.yaml
+++ b/cosmo/tests/test_case_switch_vlan.yaml
@@ -75,6 +75,5 @@ device_list:
   primary_ip4:
     __typename: IPAddressType
     address: 10.120.142.11/24
-  serial: 4242
   staticroute_set: []
 l2vpn_list: []

--- a/cosmo/tests/test_case_vendor_unknown.yaml
+++ b/cosmo/tests/test_case_vendor_unknown.yaml
@@ -10,6 +10,5 @@ device_list:
     slug: coyote-0-2-1-rc1
   primary_ip4:
     address: 45.139.136.10/32
-  serial: 4242
   staticroute_set: []
 l2vpn_list: []

--- a/cosmo/tests/test_case_vpws.yaml
+++ b/cosmo/tests/test_case_vpws.yaml
@@ -58,7 +58,6 @@ device_list:
   primary_ip4:
     __typename: IPAddressType
     address: 45.139.136.11/24
-  serial: ''
   staticroute_set: []
 - device_type:
     __typename: DeviceTypeType
@@ -120,7 +119,6 @@ device_list:
   primary_ip4:
     __typename: IPAddressType
     address: 45.139.136.10/32
-  serial: ''
   staticroute_set: []
 l2vpn_list:
 - id: '39'

--- a/cosmo/tests/test_case_vrf_staticroute.yaml
+++ b/cosmo/tests/test_case_vrf_staticroute.yaml
@@ -128,7 +128,6 @@ device_list:
   primary_ip4:
     __typename: IPAddressType
     address: 10.120.130.10/24
-  serial: 4242
   staticroute_set:
   - interface: null
     metric: null


### PR DESCRIPTION
YouTrack ticket:
https://youtrack.service.wobcom.de/issue/NE-1107

"serial" field removed from:
- query
- output
- tests