### PR TITLE
fix: Only generate RDs and export&import targets if neccessary

### DIFF
--- a/cosmo/netbox_types.py
+++ b/cosmo/netbox_types.py
@@ -387,6 +387,9 @@ class VRFType(AbstractNetboxType):
     def getRouteDistinguisher(self) -> str:
         return self["rd"]
 
+    def isMgmtVRF(self) -> bool:
+        return str(self["name"]).startswith("mgmt_")
+
 
 class IWithAssociatedDevice(Protocol, metaclass=ABCMeta):
     @abstractmethod

--- a/cosmo/routervisitor.py
+++ b/cosmo/routervisitor.py
@@ -378,9 +378,12 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor, TVRFHelpers):
         router_id = loopback.deriveRouterId()
         if o.getRouteDistinguisher():
             rd = router_id + ":" + o.getRouteDistinguisher()
-        else:
+        elif not o.isMgmtVRF():
             rd = router_id + ":" + o.getID()
-        default_targets = [self.assembleRT(o.getID())]
+        else:
+            rd = None
+
+        default_targets = [self.assembleRT(o.getID())] if not o.isMgmtVRF() else []
         import_targets = [target.getName() for target in o.getImportTargets()]
         export_targets = [target.getName() for target in o.getExportTargets()]
         return {

--- a/cosmo/tests/test_case_l3vpn.yml
+++ b/cosmo/tests/test_case_l3vpn.yml
@@ -67,6 +67,68 @@ device_list:
   - custom_fields:
       bpdufilter: false
       inner_tag: null
+      outer_tag: 101
+      storm_control__broadcast: null
+      storm_control__multicast: null
+      storm_control__unknown_unicast: null
+    __typename: InterfaceType
+    description: ''
+    enabled: true
+    id: '192118'
+    ip_addresses:
+      - address: 45.139.136.21/24
+        __typename: IPAddressType
+    lag: null
+    mac_address: null
+    mode: null
+    mtu: 1500
+    name: ifp-0/1/2.101
+    tagged_vlans: [ ]
+    tags: [ ]
+    type: VIRTUAL
+    untagged_vlan: null
+    vrf:
+      description: ''
+      export_targets: []
+      id: '408'
+      import_targets: []
+      name: L3VPN-2
+      rd: null
+      __typename: VRFType
+  - custom_fields:
+      bpdufilter: false
+      inner_tag: null
+      outer_tag: 102
+      storm_control__broadcast: null
+      storm_control__multicast: null
+      storm_control__unknown_unicast: null
+    __typename: InterfaceType
+    description: ''
+    enabled: true
+    id: '192119'
+    ip_addresses:
+      - address: 45.139.136.22/24
+        __typename: IPAddressType
+    lag: null
+    mac_address: null
+    mode: null
+    mtu: 1500
+    name: ifp-0/1/2.102
+    tagged_vlans: [ ]
+    tags: [ ]
+    type: VIRTUAL
+    untagged_vlan: null
+    vrf:
+      description: ''
+      export_targets: []
+      id: '409'
+      import_targets: []
+      name: mgmt_foo
+      rd: null
+      __typename: VRFType
+  - custom_fields:
+      bpdufilter: false
+      inner_tag: null
       outer_tag: null
       storm_control__broadcast: null
       storm_control__multicast: null

--- a/cosmo/tests/test_serializer.py
+++ b/cosmo/tests/test_serializer.py
@@ -498,23 +498,61 @@ def test_router_case_local_l3vpn():
     assert len(d["interfaces"]) == 2
 
     assert "L3VPN" in d["routing_instances"]
+    assert "L3VPN-2" in d["routing_instances"]
+    assert "mgmt_foo" in d["routing_instances"]
 
-    ri = d["routing_instances"]["L3VPN"]
+    ri_l3vpn = d["routing_instances"]["L3VPN"]
+    ri_l3vpn_2 = d["routing_instances"]["L3VPN-2"]
+    ri_mgmt_foo = d["routing_instances"]["mgmt_foo"]
 
-    assert len(ri["interfaces"]) == 1
-    assert ri["interfaces"][0] == "ifp-0/1/2.100"
-    assert ri["instance_type"] == "vrf"
+    # L3VPN
+
+    assert len(ri_l3vpn["interfaces"]) == 1
+    assert ri_l3vpn["interfaces"][0] == "ifp-0/1/2.100"
+    assert ri_l3vpn["instance_type"] == "vrf"
     assert (
         not "sampling" in d["interfaces"]["ifp-0/1/2"]["units"][100]["families"]["inet"]
     )
 
-    assert ri["route_distinguisher"] == "45.139.136.10:407"
-    assert len(ri["import_targets"]) == 1
-    assert ri["import_targets"][0] == "target:65542:407"
-    assert len(ri["export_targets"]) == 1
-    assert ri["export_targets"][0] == "target:65542:407"
+    assert ri_l3vpn["route_distinguisher"] == "45.139.136.10:407"
+    assert len(ri_l3vpn["import_targets"]) == 1
+    assert ri_l3vpn["import_targets"][0] == "target:65542:407"
+    assert len(ri_l3vpn["export_targets"]) == 1
+    assert ri_l3vpn["export_targets"][0] == "target:65542:407"
 
-    assert ri["routing_options"] == {}
+    assert ri_l3vpn["routing_options"] == {}
+
+    # L3VPN-2
+
+    assert len(ri_l3vpn_2["interfaces"]) == 1
+    assert ri_l3vpn_2["interfaces"][0] == "ifp-0/1/2.101"
+    assert ri_l3vpn_2["instance_type"] == "vrf"
+    assert (
+        not "sampling" in d["interfaces"]["ifp-0/1/2"]["units"][101]["families"]["inet"]
+    )
+
+    assert ri_l3vpn_2["route_distinguisher"] == "45.139.136.10:408"
+    assert len(ri_l3vpn_2["import_targets"]) == 1
+    assert ri_l3vpn_2["import_targets"][0] == "target:65542L:408"
+    assert len(ri_l3vpn_2["export_targets"]) == 1
+    assert ri_l3vpn_2["export_targets"][0] == "target:65542L:408"
+
+    assert ri_l3vpn_2["routing_options"] == {}
+
+    # mgmt_foo
+
+    assert len(ri_mgmt_foo["interfaces"]) == 1
+    assert ri_mgmt_foo["interfaces"][0] == "ifp-0/1/2.102"
+    assert ri_mgmt_foo["instance_type"] == "vrf"
+    assert (
+        not "sampling" in d["interfaces"]["ifp-0/1/2"]["units"][102]["families"]["inet"]
+    )
+
+    assert ri_mgmt_foo["route_distinguisher"] == None
+    assert len(ri_mgmt_foo["import_targets"]) == 0
+    assert len(ri_mgmt_foo["export_targets"]) == 0
+
+    assert ri_mgmt_foo["routing_options"] == {}
 
 
 @with_feature(features, "new-bgp-cpe-group-naming")


### PR DESCRIPTION
This is a follow-up PR on #59, which fixes a problem with routers, which uses an in-band VRF for management. At WOBCOM, this is CGRC0001.

This stops automatic generation on "management VRFs". In lack of a better mechanism to find those, I am just matching the names, better variants appreciated.

I also added tests for the automatic generation of RDs and route exports and imports.