### PR TITLE
update typing of common "head()" function to reflect None return

### DIFF
--- a/cosmo/common.py
+++ b/cosmo/common.py
@@ -53,8 +53,10 @@ def strictly_decreasing(l: Sequence[Comparable]) -> bool:
 
 
 # next() can raise StopIteration, so that's why I use this function
-# FIXME: should be head[T](l: list[T]) -> Optional[T]
-def head(l):
+T = TypeVar("T")
+
+
+def head(l: list[T]) -> Optional[T]:
     return None if not l else l[0]
 
 


### PR DESCRIPTION
makes typing issues throughout the source code visible to mypy whereas they previously weren't

TODO fix mypy errors