### PR TITLE
Fix default vrf static routes issue

### DIFF
--- a/cosmo.example.yml
+++ b/cosmo.example.yml
@@ -1,5 +1,6 @@
 fqdnSuffix: infra.example.com
 output_format: ansible
+global_vrf: global
 asn: 65542
 features:
   interface-auto-descriptions: YES

--- a/cosmo/__main__.py
+++ b/cosmo/__main__.py
@@ -131,7 +131,6 @@ def main() -> int:
                     device,
                     cosmo_data["l2vpn_list"],
                     cosmo_data["loopbacks"],
-                    cosmo_configuration["asn"],
                     cosmo_configuration,
                 )
                 content = router_serializer.serialize()

--- a/cosmo/__main__.py
+++ b/cosmo/__main__.py
@@ -132,10 +132,11 @@ def main() -> int:
                     cosmo_data["l2vpn_list"],
                     cosmo_data["loopbacks"],
                     cosmo_configuration["asn"],
+                    cosmo_configuration,
                 )
                 content = router_serializer.serialize()
             elif device["name"] in cosmo_configuration["devices"]["switch"]:
-                switch_serializer = SwitchSerializer(device)
+                switch_serializer = SwitchSerializer(device, cosmo_configuration)
                 content = switch_serializer.serialize()
         except DeviceSerializationError as dse:
             error(

--- a/cosmo/abstractroutervisitor.py
+++ b/cosmo/abstractroutervisitor.py
@@ -5,9 +5,6 @@ from cosmo.visitors import AbstractNoopNetboxTypesVisitor
 
 
 class AbstractRouterExporterVisitor(AbstractNoopNetboxTypesVisitor, ABC):
-    _vrf_key = (
-        "routing_instances"  # TODO: deleteme, use manufacturer VRF methods instead
-    )
     _interfaces_key = "interfaces"
     _mgmt_vrf_description = "MGMT-ROUTING-INSTANCE"
     _l2circuits_key = "l2circuits"

--- a/cosmo/abstractroutervisitor.py
+++ b/cosmo/abstractroutervisitor.py
@@ -9,7 +9,7 @@ class AbstractRouterExporterVisitor(AbstractNoopNetboxTypesVisitor, ABC):
         "routing_instances"  # TODO: deleteme, use manufacturer VRF methods instead
     )
     _interfaces_key = "interfaces"
-    _mgmt_vrf_name = "MGMT-ROUTING-INSTANCE"  # TODO: yank me in config
+    _mgmt_vrf_description = "MGMT-ROUTING-INSTANCE"
     _l2circuits_key = "l2circuits"
     _pools_key = "pools"
     _allowed_core_mtus = [9216, 9586, 9116]

--- a/cosmo/abstractroutervisitor.py
+++ b/cosmo/abstractroutervisitor.py
@@ -5,9 +5,11 @@ from cosmo.visitors import AbstractNoopNetboxTypesVisitor
 
 
 class AbstractRouterExporterVisitor(AbstractNoopNetboxTypesVisitor, ABC):
-    _vrf_key = "routing_instances"
+    _vrf_key = (
+        "routing_instances"  # TODO: deleteme, use manufacturer VRF methods instead
+    )
     _interfaces_key = "interfaces"
-    _mgmt_vrf_name = "MGMT-ROUTING-INSTANCE"
+    _mgmt_vrf_name = "MGMT-ROUTING-INSTANCE"  # TODO: yank me in config
     _l2circuits_key = "l2circuits"
     _pools_key = "pools"
     _allowed_core_mtus = [9216, 9586, 9116]

--- a/cosmo/config/cosmo_config.py
+++ b/cosmo/config/cosmo_config.py
@@ -2,7 +2,7 @@ import json
 import os
 from os import PathLike
 from pathlib import Path
-from typing import Never
+from typing import Never, Final
 
 import yaml
 from jsonschema import validate
@@ -12,6 +12,7 @@ from cosmo.features import features
 
 class CosmoConfig:
     SCHEMA_PATH = Path(__file__).parent.joinpath(Path("cosmo_config.schema.json"))
+    GLOBAL_VRF_KEY = "global_vrf"
 
     @staticmethod
     def get_raw_config(config_file_path) -> str | Never:
@@ -43,3 +44,6 @@ class CosmoConfig:
 
     def toDict(self) -> dict:
         return self._store
+
+    def getGlobalVRFName(self) -> str:
+        return self.get(self.GLOBAL_VRF_KEY)

--- a/cosmo/config/cosmo_config.schema.json
+++ b/cosmo/config/cosmo_config.schema.json
@@ -20,6 +20,9 @@
       "minimum": 1,
       "maximum": 4294967294
     },
+    "global_vrf": {
+      "type": "string"
+    },
     "output_format": {
       "type": "string",
       "enum": ["nix", "ansible"]
@@ -44,7 +47,7 @@
       "required": ["switch", "router"]
     }
   },
-  "required": ["asn", "output_format", "devices"],
+  "required": ["asn", "output_format", "devices", "global_vrf"],
   "$defs": {
     "hostname": {
       "type": "string",

--- a/cosmo/l2vpnhelpertypes.py
+++ b/cosmo/l2vpnhelpertypes.py
@@ -367,6 +367,7 @@ class AbstractVPWSEVPNVPWSVpnTypeCommon(
     def needsL2VPNIdentifierAsMandatory(self) -> bool:
         return True
 
+    # TODO: fix vrf
     def processInterfaceTypeTermination(self, o: InterfaceType) -> dict | None:
         parent_l2vpn = o.getParent(L2VPNType)
         parent_device = o.getParent(DeviceType)

--- a/cosmo/l2vpnhelpertypes.py
+++ b/cosmo/l2vpnhelpertypes.py
@@ -10,7 +10,9 @@ from cosmo.common import (
     L2VPNSerializationError,
     DeviceSerializationError,
 )
+from cosmo.config.cosmo_config import CosmoConfig
 from cosmo.loopbacks import LoopbackHelper
+from cosmo.manufacturers import ManufacturerFactoryFromDevice
 from cosmo.vrfhelper import TVRFHelpers
 from cosmo.log import warn
 from cosmo.netbox_types import (
@@ -95,6 +97,7 @@ class AbstractL2VpnTypeTerminationVisitor(
         *args,
         associated_l2vpn: L2VPNType,
         loopbacks: LoopbackHelper,
+        cosmo_config: CosmoConfig,
         asn: int,
         **kwargs,
     ):
@@ -102,6 +105,7 @@ class AbstractL2VpnTypeTerminationVisitor(
         self.associated_l2vpn = associated_l2vpn
         self.loopbacks = loopbacks
         self.asn = asn
+        self._cosmo_config = cosmo_config
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self.associated_l2vpn})"
@@ -367,10 +371,12 @@ class AbstractVPWSEVPNVPWSVpnTypeCommon(
     def needsL2VPNIdentifierAsMandatory(self) -> bool:
         return True
 
-    # TODO: fix vrf
     def processInterfaceTypeTermination(self, o: InterfaceType) -> dict | None:
         parent_l2vpn = o.getParent(L2VPNType)
         parent_device = o.getParent(DeviceType)
+        manufacturer = ManufacturerFactoryFromDevice(
+            parent_device, self._cosmo_config
+        ).get()
         # find local end
         local = next(
             filter(
@@ -383,37 +389,32 @@ class AbstractVPWSEVPNVPWSVpnTypeCommon(
 
         loopback = self.loopbacks.getByDevice(parent_device.getName())
         router_id = loopback.deriveRouterId()
-        return {
-            self._vrf_key: {
-                parent_l2vpn.getName().replace("WAN: ", ""): {
-                    "interfaces": [o.getName()],
-                    "description": f"VPWS: {parent_l2vpn.getName().replace('WAN: VS_', '')}",
-                    "instance_type": "evpn-vpws",
-                    "route_distinguisher": f"{router_id}:{str(parent_l2vpn.getIdentifier())}",
-                    "vrf_target": self.assembleRT(parent_l2vpn.getIdentifier()),
-                    "protocols": {
-                        "evpn": {
-                            "interfaces": {
-                                o.getName(): {
-                                    "vpws_service_id": {
-                                        "local": int(
-                                            local.getParent(
-                                                L2VPNTerminationType
-                                            ).getID()
-                                        ),
-                                        "remote": int(
-                                            remote.getParent(
-                                                L2VPNTerminationType
-                                            ).getID()
-                                        ),
-                                    }
+        return manufacturer.spitVRFPathWith(
+            parent_l2vpn.getName().replace("WAN: ", ""),
+            {
+                "interfaces": [o.getName()],
+                "description": f"VPWS: {parent_l2vpn.getName().replace('WAN: VS_', '')}",
+                "instance_type": "evpn-vpws",
+                "route_distinguisher": f"{router_id}:{str(parent_l2vpn.getIdentifier())}",
+                "vrf_target": self.assembleRT(parent_l2vpn.getIdentifier()),
+                "protocols": {
+                    "evpn": {
+                        "interfaces": {
+                            o.getName(): {
+                                "vpws_service_id": {
+                                    "local": int(
+                                        local.getParent(L2VPNTerminationType).getID()
+                                    ),
+                                    "remote": int(
+                                        remote.getParent(L2VPNTerminationType).getID()
+                                    ),
                                 }
                             }
                         }
-                    },
-                }
-            }
-        } | self.spitInterfaceEncapFor(o)
+                    }
+                },
+            },
+        ) | self.spitInterfaceEncapFor(o)
 
 
 class VPWSL2VpnTypeTerminationVisitor(
@@ -460,6 +461,10 @@ class MPLSEVPNL2VpnTypeTerminationVisitor(AbstractAnyToAnyL2VpnTypeTerminationVi
 
     def processTerminationCommon(self, o: InterfaceType | VLANType) -> dict | None:
         parent_l2vpn = o.getParent(L2VPNType)
+        parent_device = o.getParent(DeviceType)
+        manufacturer = ManufacturerFactoryFromDevice(
+            parent_device, self._cosmo_config
+        ).get()
         interface_names = None
         warn(
             f"{parent_l2vpn.getName()} is of type {self.getNetboxTypeName()} which is deprecated.",
@@ -484,20 +489,19 @@ class MPLSEVPNL2VpnTypeTerminationVisitor(AbstractAnyToAnyL2VpnTypeTerminationVi
                 )
             )
 
-        return {
-            self._vrf_key: {
-                parent_l2vpn.getName().replace("WAN: ", ""): {
-                    "interfaces": interface_names,
-                    "description": f"MPLS-EVPN: {parent_l2vpn.getName().replace('WAN: VS_', '')}",
-                    "instance_type": "evpn",
-                    "protocols": {
-                        "evpn": {},
-                    },
-                    "route_distinguisher": f"{self.asn}:{str(parent_l2vpn.getIdentifier())}",
-                    "vrf_target": f"target:1:{str(parent_l2vpn.getIdentifier())}",
-                }
-            }
-        } | self.spitInterfaceEncapFor(o)
+        return manufacturer.spitVRFPathWith(
+            parent_l2vpn.getName().replace("WAN: ", ""),
+            {
+                "interfaces": interface_names,
+                "description": f"MPLS-EVPN: {parent_l2vpn.getName().replace('WAN: VS_', '')}",
+                "instance_type": "evpn",
+                "protocols": {
+                    "evpn": {},
+                },
+                "route_distinguisher": f"{self.asn}:{str(parent_l2vpn.getIdentifier())}",
+                "vrf_target": f"target:1:{str(parent_l2vpn.getIdentifier())}",
+            },
+        ) | self.spitInterfaceEncapFor(o)
 
     def processInterfaceTypeTermination(self, o: InterfaceType) -> dict | None:
         return self.processTerminationCommon(o)

--- a/cosmo/l2vpnhelpertypes.py
+++ b/cosmo/l2vpnhelpertypes.py
@@ -98,14 +98,13 @@ class AbstractL2VpnTypeTerminationVisitor(
         associated_l2vpn: L2VPNType,
         loopbacks: LoopbackHelper,
         cosmo_config: CosmoConfig,
-        asn: int,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self.associated_l2vpn = associated_l2vpn
         self.loopbacks = loopbacks
-        self.asn = asn
         self._cosmo_config = cosmo_config
+        self.asn = self._cosmo_config["asn"]
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self.associated_l2vpn})"

--- a/cosmo/manufacturers.py
+++ b/cosmo/manufacturers.py
@@ -1,12 +1,19 @@
 import re
 from abc import ABC, abstractmethod
-from typing import NoReturn
+from typing import NoReturn, Final, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from cosmo.config.cosmo_config import CosmoConfig
+
 
 from cosmo.common import DeviceSerializationError
-from cosmo.netbox_types import DeviceType, InterfaceType, PlatformType
+from cosmo.netbox_types import DeviceType, InterfaceType, PlatformType, VRFType
 
 
 class AbstractManufacturer(ABC):
+    def __init__(self, cosmo_config: "CosmoConfig"):
+        self._cosmo_config: "CosmoConfig" = cosmo_config
+
     @classmethod
     def isCompatibleWith(cls, device: DeviceType):
         # Note: If the platform cannot be parsed, getPlatform will be a string.
@@ -41,6 +48,23 @@ class AbstractManufacturer(ABC):
     def isManagementInterface(self, o: InterfaceType):
         pass
 
+    @classmethod
+    @abstractmethod
+    def _spitDefaultVRFPathWith(cls, d: dict) -> dict:
+        pass
+
+    @classmethod
+    @abstractmethod
+    def _spitOtherVRFPathWith(cls, v: str, d: dict) -> dict:
+        pass
+
+    def spitVRFPathWith(self, v: VRFType | str, d: dict) -> dict:
+        v = str(v)
+        if v == self._cosmo_config.getGlobalVRFName():
+            return self._spitDefaultVRFPathWith(d)
+        else:
+            return self._spitOtherVRFPathWith(v, d)
+
     @staticmethod
     @abstractmethod
     def hasMTUInheritance():
@@ -48,6 +72,8 @@ class AbstractManufacturer(ABC):
 
 
 class JuniperManufacturer(AbstractManufacturer):
+    VRF_KEY: Final[str] = "routing_instances"
+    ROUTING_OPTIONS_KEY: Final[str] = "routing_options"
     _platform_re = re.compile(r"REPLACEME")
 
     @staticmethod
@@ -69,8 +95,18 @@ class JuniperManufacturer(AbstractManufacturer):
     def hasMTUInheritance():
         return True
 
+    @classmethod
+    def _spitDefaultVRFPathWith(cls, d: dict) -> dict:
+        return {cls.ROUTING_OPTIONS_KEY: {**d}}
+
+    @classmethod
+    def _spitOtherVRFPathWith(cls, v: str, d: dict) -> dict:
+        return {cls.VRF_KEY: {v: {**d}}}
+
 
 class RtBrickManufacturer(AbstractManufacturer):
+    VRF_KEY: Final[str] = "routing_instances"
+    DEFAULT_VRF_KEY: Final[str] = "default"
     _platform_re = re.compile(r"REPLACEME")
 
     @staticmethod
@@ -93,6 +129,14 @@ class RtBrickManufacturer(AbstractManufacturer):
     @staticmethod
     def hasMTUInheritance():
         return False
+
+    @classmethod
+    def _spitDefaultVRFPathWith(cls, d: dict) -> dict:
+        return {cls.VRF_KEY: {cls.DEFAULT_VRF_KEY: {**d}}}
+
+    @classmethod
+    def _spitOtherVRFPathWith(cls, v: str, d: dict) -> dict:
+        return {cls.VRF_KEY: {v: {**d}}}
 
 
 class CumulusNetworksManufacturer(AbstractManufacturer):
@@ -117,6 +161,14 @@ class CumulusNetworksManufacturer(AbstractManufacturer):
     def hasMTUInheritance():
         return False
 
+    @classmethod
+    def _spitDefaultVRFPathWith(cls, d: dict) -> dict:
+        raise NotImplementedError
+
+    @classmethod
+    def _spitOtherVRFPathWith(cls, v, d: dict) -> dict:
+        raise NotImplementedError
+
 
 # This is needed in order to avoid accidentally initializing the ABC.
 # Also enables us to extract type matching from the ABC.
@@ -127,11 +179,13 @@ class ManufacturerFactoryFromDevice:
         JuniperManufacturer,
     )
 
-    def __init__(self, device: DeviceType):
+    #                                      v    dependency injection
+    def __init__(self, device: DeviceType, cosmo_config: "CosmoConfig"):
         self._device = device
+        self._cosmo_config = cosmo_config
 
     def get(self) -> AbstractManufacturer | NoReturn:
         for c in self._all_manufacturers:
             if c.isCompatibleWith(self._device):
-                return c()
+                return c(self._cosmo_config)
         raise Exception(f"Cannot find suitable manufacturer for device {self._device}")

--- a/cosmo/manufacturers.py
+++ b/cosmo/manufacturers.py
@@ -58,11 +58,11 @@ class AbstractManufacturer(ABC):
     def _spitOtherVRFPathWith(cls, v: str, d: dict) -> dict:
         pass
 
-    def _isGlobalVRF(self, v: VRFType | str):
+    def isGlobalVRF(self, v: VRFType | str) -> bool:
         return str(v) == self._cosmo_config.getGlobalVRFName()
 
     def spitVRFPathWith(self, v: VRFType | str, d: dict) -> dict:
-        if self._isGlobalVRF(v):
+        if self.isGlobalVRF(v):
             return self._spitDefaultVRFPathWith(d)
         else:
             return self._spitOtherVRFPathWith(str(v), d)
@@ -92,16 +92,16 @@ class AbstractJuniperRtBrickManufacturerCommon(AbstractManufacturer, ABC):
     def spitRoutingOptionsPathWith(self, v: VRFType | str, d: dict) -> dict:
         return self.spitVRFPathWith(v, {self.ROUTING_OPTIONS_KEY: d})
 
-    def getRibTableNameFor(self, v: VRFType, af: int) -> str:
-        match self._isGlobalVRF(v), af:
+    def getRibTableNameFor(self, v: VRFType | str, af: int) -> str:
+        match self.isGlobalVRF(v), af:
             case True, 4:
                 return "inet.0"
             case True, 6:
                 return "inet6.0"
             case False, 4:
-                return f"{v.getName()}.inet.0"
+                return f"{v}.inet.0"
             case False, 6:
-                return f"{v.getName()}.inet6.0"
+                return f"{v}.inet6.0"
             case _:
                 raise NotImplementedError
 

--- a/cosmo/manufacturers.py
+++ b/cosmo/manufacturers.py
@@ -55,14 +55,25 @@ class AbstractManufacturer(ABC):
 
     @classmethod
     @abstractmethod
-    def _spitOtherVRFPathWith(cls, v, d: dict) -> dict:
+    def _spitOtherVRFPathWith(cls, v: str, d: dict) -> dict:
         pass
 
-    def spitVRFPathWith(self, v: VRFType, d: dict) -> dict:
-        if v.getName() == self._cosmo_config.getGlobalVRFName():
+    def _isGlobalVRF(self, v: VRFType | str):
+        return str(v) == self._cosmo_config.getGlobalVRFName()
+
+    def spitVRFPathWith(self, v: VRFType | str, d: dict) -> dict:
+        if self._isGlobalVRF(v):
             return self._spitDefaultVRFPathWith(d)
         else:
-            return self._spitOtherVRFPathWith(v, d)
+            return self._spitOtherVRFPathWith(str(v), d)
+
+    @abstractmethod
+    def spitRoutingOptionsPathWith(self, v: VRFType | str, d: dict) -> dict:
+        pass
+
+    @abstractmethod
+    def getRibTableNameFor(self, v: VRFType, af: int) -> str:
+        pass
 
     @staticmethod
     @abstractmethod
@@ -70,9 +81,32 @@ class AbstractManufacturer(ABC):
         pass
 
 
-class JuniperManufacturer(AbstractManufacturer):
+class AbstractJuniperRtBrickManufacturerCommon(AbstractManufacturer, ABC):
     VRF_KEY: Final[str] = "routing_instances"
     ROUTING_OPTIONS_KEY: Final[str] = "routing_options"
+
+    @classmethod
+    def _spitOtherVRFPathWith(cls, v: str, d: dict) -> dict:
+        return {cls.VRF_KEY: {v: {**d}}}
+
+    def spitRoutingOptionsPathWith(self, v: VRFType | str, d: dict) -> dict:
+        return self.spitVRFPathWith(v, {self.ROUTING_OPTIONS_KEY: d})
+
+    def getRibTableNameFor(self, v: VRFType, af: int) -> str:
+        match self._isGlobalVRF(v), af:
+            case True, 4:
+                return "inet.0"
+            case True, 6:
+                return "inet6.0"
+            case False, 4:
+                return f"{v.getName()}.inet.0"
+            case False, 6:
+                return f"{v.getName()}.inet6.0"
+            case _:
+                raise NotImplementedError
+
+
+class JuniperManufacturer(AbstractJuniperRtBrickManufacturerCommon):
     _platform_re = re.compile(r"REPLACEME")
 
     @staticmethod
@@ -96,15 +130,10 @@ class JuniperManufacturer(AbstractManufacturer):
 
     @classmethod
     def _spitDefaultVRFPathWith(cls, d: dict) -> dict:
-        return {cls.ROUTING_OPTIONS_KEY: {**d}}
-
-    @classmethod
-    def _spitOtherVRFPathWith(cls, v, d: dict) -> dict:
-        return {cls.VRF_KEY: {v.getName(): {**d}}}
+        return {**d}
 
 
-class RtBrickManufacturer(AbstractManufacturer):
-    VRF_KEY: Final[str] = "routing_instances"
+class RtBrickManufacturer(AbstractJuniperRtBrickManufacturerCommon):
     DEFAULT_VRF_KEY: Final[str] = "default"
     _platform_re = re.compile(r"REPLACEME")
 
@@ -132,10 +161,6 @@ class RtBrickManufacturer(AbstractManufacturer):
     @classmethod
     def _spitDefaultVRFPathWith(cls, d: dict) -> dict:
         return {cls.VRF_KEY: {cls.DEFAULT_VRF_KEY: {**d}}}
-
-    @classmethod
-    def _spitOtherVRFPathWith(cls, v, d: dict) -> dict:
-        return {cls.VRF_KEY: {v.getName(): {**d}}}
 
 
 class CumulusNetworksManufacturer(AbstractManufacturer):
@@ -166,6 +191,12 @@ class CumulusNetworksManufacturer(AbstractManufacturer):
 
     @classmethod
     def _spitOtherVRFPathWith(cls, v, d: dict) -> dict:
+        raise NotImplementedError
+
+    def spitRoutingOptionsPathWith(self, v: VRFType | str, d: dict) -> dict:
+        raise NotImplementedError
+
+    def getRibTableNameFor(self, v: VRFType, af: int) -> str:
         raise NotImplementedError
 
 

--- a/cosmo/manufacturers.py
+++ b/cosmo/manufacturers.py
@@ -55,12 +55,11 @@ class AbstractManufacturer(ABC):
 
     @classmethod
     @abstractmethod
-    def _spitOtherVRFPathWith(cls, v: str, d: dict) -> dict:
+    def _spitOtherVRFPathWith(cls, v, d: dict) -> dict:
         pass
 
-    def spitVRFPathWith(self, v: VRFType | str, d: dict) -> dict:
-        v = str(v)
-        if v == self._cosmo_config.getGlobalVRFName():
+    def spitVRFPathWith(self, v: VRFType, d: dict) -> dict:
+        if v.getName() == self._cosmo_config.getGlobalVRFName():
             return self._spitDefaultVRFPathWith(d)
         else:
             return self._spitOtherVRFPathWith(v, d)
@@ -100,8 +99,8 @@ class JuniperManufacturer(AbstractManufacturer):
         return {cls.ROUTING_OPTIONS_KEY: {**d}}
 
     @classmethod
-    def _spitOtherVRFPathWith(cls, v: str, d: dict) -> dict:
-        return {cls.VRF_KEY: {v: {**d}}}
+    def _spitOtherVRFPathWith(cls, v, d: dict) -> dict:
+        return {cls.VRF_KEY: {v.getName(): {**d}}}
 
 
 class RtBrickManufacturer(AbstractManufacturer):
@@ -135,8 +134,8 @@ class RtBrickManufacturer(AbstractManufacturer):
         return {cls.VRF_KEY: {cls.DEFAULT_VRF_KEY: {**d}}}
 
     @classmethod
-    def _spitOtherVRFPathWith(cls, v: str, d: dict) -> dict:
-        return {cls.VRF_KEY: {v: {**d}}}
+    def _spitOtherVRFPathWith(cls, v, d: dict) -> dict:
+        return {cls.VRF_KEY: {v.getName(): {**d}}}
 
 
 class CumulusNetworksManufacturer(AbstractManufacturer):

--- a/cosmo/manufacturers.py
+++ b/cosmo/manufacturers.py
@@ -41,7 +41,7 @@ class AbstractManufacturer(ABC):
 
     @staticmethod
     @abstractmethod
-    def getRoutingInstanceName():
+    def getManagementVRFName():
         pass
 
     @abstractmethod
@@ -84,7 +84,7 @@ class JuniperManufacturer(AbstractManufacturer):
         return cls._platform_re
 
     @staticmethod
-    def getRoutingInstanceName():
+    def getManagementVRFName():
         return "mgmt_junos"
 
     def isManagementInterface(self, o: InterfaceType):
@@ -117,7 +117,7 @@ class RtBrickManufacturer(AbstractManufacturer):
         return cls._platform_re
 
     @staticmethod
-    def getRoutingInstanceName():
+    def getManagementVRFName():
         return "mgmt"
 
     def isManagementInterface(self, o: InterfaceType):
@@ -150,7 +150,7 @@ class CumulusNetworksManufacturer(AbstractManufacturer):
         return cls._platform_re
 
     @staticmethod
-    def getRoutingInstanceName():
+    def getManagementVRFName():
         return "mgmt"
 
     def isManagementInterface(self, o: InterfaceType):

--- a/cosmo/netbox_types.py
+++ b/cosmo/netbox_types.py
@@ -380,6 +380,9 @@ class RouteTargetType(AbstractNetboxType):
 
 
 class VRFType(AbstractNetboxType):
+    def __str__(self):
+        return self.getName()
+
     def getBasePath(self):
         return "/ipam/vrfs/"
 

--- a/cosmo/routerbgpcpevisitor.py
+++ b/cosmo/routerbgpcpevisitor.py
@@ -19,8 +19,8 @@ from cosmo.netbox_types import (
 
 
 class AbstractBgpCpeExporter(metaclass=ABCMeta):
-    _vrf_key = "routing_instances"
-    _default_vrf_name = "default"
+    _vrf_key = "routing_instances"  # TODO: deleteme
+    _default_vrf_name = "default"  # TODO: deleteme
 
     @abstractmethod
     def getOptionalMaxPrefixAttrs(self) -> CosmoOutputType:
@@ -151,6 +151,7 @@ class AbstractBgpCpeExporter(metaclass=ABCMeta):
         else:  # use new naming scheme with tobago line name
             return "CUST_" + attached_tobago_line.getLineNameLong()
 
+    # TODO: fix vrf
     def processBgpCpeTag(self, o: TagType):
         linked_interface = o.getParent(InterfaceType)
         if not linked_interface.hasParentInterface():

--- a/cosmo/routerbgpcpevisitor.py
+++ b/cosmo/routerbgpcpevisitor.py
@@ -5,10 +5,12 @@ from multimethod import multimethod as singledispatchmethod
 from ipaddress import IPv4Interface, IPv6Interface
 
 from cosmo.common import head, CosmoOutputType, InterfaceSerializationError
+from cosmo.config.cosmo_config import CosmoConfig
 from cosmo.cperoutervisitor import CpeRouterExporterVisitor, CpeRouterIPVisitor
 from cosmo.abstractroutervisitor import AbstractRouterExporterVisitor
 from cosmo.features import features
 from cosmo.log import warn
+from cosmo.manufacturers import ManufacturerFactoryFromDevice
 from cosmo.netbox_types import (
     TagType,
     InterfaceType,
@@ -19,8 +21,8 @@ from cosmo.netbox_types import (
 
 
 class AbstractBgpCpeExporter(metaclass=ABCMeta):
-    _vrf_key = "routing_instances"  # TODO: deleteme
-    _default_vrf_name = "default"  # TODO: deleteme
+    def __init__(self, cosmo_config: CosmoConfig):
+        self._cosmo_config = cosmo_config
 
     @abstractmethod
     def getOptionalMaxPrefixAttrs(self) -> CosmoOutputType:
@@ -151,9 +153,11 @@ class AbstractBgpCpeExporter(metaclass=ABCMeta):
         else:  # use new naming scheme with tobago line name
             return "CUST_" + attached_tobago_line.getLineNameLong()
 
-    # TODO: fix vrf
     def processBgpCpeTag(self, o: TagType):
         linked_interface = o.getParent(InterfaceType)
+        manufacturer = ManufacturerFactoryFromDevice(
+            o.getParent(DeviceType), self._cosmo_config
+        ).get()
         if not linked_interface.hasParentInterface():
             warn(
                 f"does not have a parent interface configured, skipping...",
@@ -176,7 +180,7 @@ class AbstractBgpCpeExporter(metaclass=ABCMeta):
             return
 
         group_name = self.getGroupName(linked_interface, parent_interface)
-        vrf_name = self._default_vrf_name
+        vrf_name = self._cosmo_config.getGlobalVRFName()
         # make the type checker happy, since it cannot reliably infer
         # type from default values of policy_v4 and policy_v6
         policy_v4: CosmoOutputType = {"import_list": []}
@@ -188,7 +192,7 @@ class AbstractBgpCpeExporter(metaclass=ABCMeta):
         if isinstance(vrf_object, VRFType):
             vrf_name = vrf_object.getName()
         self.acceptVRFNameOrFailOn(vrf_name, linked_interface)
-        if vrf_name == self._default_vrf_name:
+        if manufacturer.isGlobalVRF(vrf_name):
             policy_v4["export"] = ["DEFAULT_V4"]
             policy_v6["export"] = ["DEFAULT_V6"]
 
@@ -221,7 +225,9 @@ class AbstractBgpCpeExporter(metaclass=ABCMeta):
             groups = self.processUnnumberedBGP(
                 group_name, linked_interface, policy_v4, policy_v6
             )
-        return {self._vrf_key: {vrf_name: {"protocols": {"bgp": {"groups": groups}}}}}
+        return manufacturer.spitVRFPathWith(
+            vrf_name, {"protocols": {"bgp": {"groups": groups}}}
+        )
 
 
 class MaxPrefixBgpCpeExporter(AbstractBgpCpeExporter):
@@ -230,7 +236,7 @@ class MaxPrefixBgpCpeExporter(AbstractBgpCpeExporter):
         self.max_prefix_n = max_prefix_n
 
     def acceptVRFNameOrFailOn(self, vrf_name: str, on: AbstractNetboxType):
-        if vrf_name == self._default_vrf_name:
+        if vrf_name == self._cosmo_config.getGlobalVRFName():
             raise InterfaceSerializationError(
                 f"forbidden use of max-prefix in default vrf", on=on
             )
@@ -263,6 +269,9 @@ class DefinedImportListBgpCpeExporter(AbstractBgpCpeExporter):
 
 
 class RouterBgpCpeExporterVisitor(AbstractRouterExporterVisitor):
+    def __init__(self, cosmo_config: CosmoConfig):
+        self._cosmo_config = cosmo_config
+
     @singledispatchmethod
     def accept(self, o):
         return super().accept(o)
@@ -272,7 +281,10 @@ class RouterBgpCpeExporterVisitor(AbstractRouterExporterVisitor):
         if "bgp:cpe" in o and "max-prefixes" in o:
             prefix_tag = head(TagType.filterTags(o, "max-prefixes"))
             return MaxPrefixBgpCpeExporter(
-                max_prefix_n=int(prefix_tag.getTagValue())
+                max_prefix_n=int(prefix_tag.getTagValue()),
+                cosmo_config=self._cosmo_config,
             ).processBgpCpeTag(head(o))
         elif "bgp:cpe" in o:
-            return DefinedImportListBgpCpeExporter().processBgpCpeTag(head(o))
+            return DefinedImportListBgpCpeExporter(
+                cosmo_config=self._cosmo_config
+            ).processBgpCpeTag(head(o))

--- a/cosmo/routerl2vpnvisitor.py
+++ b/cosmo/routerl2vpnvisitor.py
@@ -3,6 +3,7 @@ from multimethod import multimethod as singledispatchmethod
 
 from cosmo.abstractroutervisitor import AbstractRouterExporterVisitor
 from cosmo.common import head, L2VPNSerializationError
+from cosmo.config.cosmo_config import CosmoConfig
 from cosmo.l2vpnhelpertypes import (
     L2VpnVisitorClassFactoryFromL2VpnTypeObject,
     AbstractL2VpnTypeTerminationVisitor,
@@ -24,11 +25,13 @@ class AbstractL2VPNVisitor(AbstractRouterExporterVisitor):
         *args,
         loopbacks: LoopbackHelper,
         asn: int,
+        cosmo_config: CosmoConfig,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self.loopbacks = loopbacks
         self.asn = asn
+        self._cosmo_config = cosmo_config
 
     @singledispatchmethod
     def accept(self, o):
@@ -41,6 +44,7 @@ class AbstractL2VPNVisitor(AbstractRouterExporterVisitor):
             associated_l2vpn=o,
             loopbacks=self.loopbacks,
             asn=self.asn,
+            cosmo_config=self._cosmo_config,
         )
 
 

--- a/cosmo/routerl2vpnvisitor.py
+++ b/cosmo/routerl2vpnvisitor.py
@@ -21,17 +21,12 @@ from cosmo.netbox_types import (
 
 class AbstractL2VPNVisitor(AbstractRouterExporterVisitor):
     def __init__(
-        self,
-        *args,
-        loopbacks: LoopbackHelper,
-        asn: int,
-        cosmo_config: CosmoConfig,
-        **kwargs,
+        self, *args, loopbacks: LoopbackHelper, cosmo_config: CosmoConfig, **kwargs
     ):
         super().__init__(*args, **kwargs)
         self.loopbacks = loopbacks
-        self.asn = asn
         self._cosmo_config = cosmo_config
+        self.asn = self._cosmo_config["asn"]
 
     @singledispatchmethod
     def accept(self, o):
@@ -43,7 +38,6 @@ class AbstractL2VPNVisitor(AbstractRouterExporterVisitor):
         return L2VpnVisitorClassFactoryFromL2VpnTypeObject(o).get()(
             associated_l2vpn=o,
             loopbacks=self.loopbacks,
-            asn=self.asn,
             cosmo_config=self._cosmo_config,
         )
 

--- a/cosmo/routervisitor.py
+++ b/cosmo/routervisitor.py
@@ -88,11 +88,12 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor, TVRFHelpers):
         isis = {}
         if isis_system_id := o.getISISIdentifier():
             isis["isis"] = {"system_id": isis_system_id}
-        return manufacturer.spitVRFPathWith(
-            manufacturer.getManagementVRFName(),
-            {"description": self._mgmt_vrf_description},
-        ) | {
+        return {
             **isis,
+            **manufacturer.spitVRFPathWith(
+                manufacturer.getManagementVRFName(),
+                {"description": self._mgmt_vrf_description},
+            ),
             self._pools_key: {
                 # this one should always exist
             },

--- a/cosmo/routervisitor.py
+++ b/cosmo/routervisitor.py
@@ -43,22 +43,15 @@ from cosmo.netbox_types import (
 
 
 class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor, TVRFHelpers):
-    def __init__(
-        self,
-        loopbacks: LoopbackHelper,
-        asn: int,
-        cosmo_config: CosmoConfig,
-        *args,
-        **kwargs,
-    ):
-        super().__init__(*args, **kwargs)
+    def __init__(self, loopbacks: LoopbackHelper, cosmo_config: CosmoConfig):
         self._cosmo_config = cosmo_config
+        self.asn = self._cosmo_config["asn"]
         # Note: I have to use composition since singledispatchmethod does not work well with inheritance
         self.l2vpn_exporter = RouterL2VPNExporterVisitor(
-            loopbacks=loopbacks, asn=asn, cosmo_config=self._cosmo_config
+            loopbacks=loopbacks, cosmo_config=self._cosmo_config
         )
         self.l2vpn_validator = RouterL2VPNValidatorVisitor(
-            loopbacks=loopbacks, asn=asn, cosmo_config=self._cosmo_config
+            loopbacks=loopbacks, cosmo_config=self._cosmo_config
         )
         self.bgpcpe_exporter = RouterBgpCpeExporterVisitor(
             cosmo_config=self._cosmo_config
@@ -67,7 +60,6 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor, TVRFHelpers):
         self.allow_private_ips = features.featureIsEnabled(
             "allow-private-ips-default-vrf"
         )
-        self.asn = asn
 
     def getASN(self) -> int:
         return self.asn

--- a/cosmo/routervisitor.py
+++ b/cosmo/routervisitor.py
@@ -90,13 +90,11 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor, TVRFHelpers):
         isis = {}
         if isis_system_id := o.getISISIdentifier():
             isis["isis"] = {"system_id": isis_system_id}
-        return {
+        return manufacturer.spitVRFPathWith(
+            manufacturer.getManagementVRFName(),
+            {"description": self._mgmt_vrf_description},
+        ) | {
             **isis,
-            self._vrf_key: {
-                manufacturer.getManagementVRFName(): {
-                    "description": self._mgmt_vrf_name,
-                }
-            },
             self._pools_key: {
                 # this one should always exist
             },

--- a/cosmo/routervisitor.py
+++ b/cosmo/routervisitor.py
@@ -52,16 +52,20 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor, TVRFHelpers):
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
+        self._cosmo_config = cosmo_config
         # Note: I have to use composition since singledispatchmethod does not work well with inheritance
-        self.l2vpn_exporter = RouterL2VPNExporterVisitor(loopbacks=loopbacks, asn=asn)
-        self.l2vpn_validator = RouterL2VPNValidatorVisitor(loopbacks=loopbacks, asn=asn)
+        self.l2vpn_exporter = RouterL2VPNExporterVisitor(
+            loopbacks=loopbacks, asn=asn, cosmo_config=self._cosmo_config
+        )
+        self.l2vpn_validator = RouterL2VPNValidatorVisitor(
+            loopbacks=loopbacks, asn=asn, cosmo_config=self._cosmo_config
+        )
         self.bgpcpe_exporter = RouterBgpCpeExporterVisitor()
         self.loopbacks = loopbacks
         self.allow_private_ips = features.featureIsEnabled(
             "allow-private-ips-default-vrf"
         )
         self.asn = asn
-        self._cosmo_config = cosmo_config
 
     def getASN(self) -> int:
         return self.asn

--- a/cosmo/routervisitor.py
+++ b/cosmo/routervisitor.py
@@ -93,7 +93,7 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor, TVRFHelpers):
         return {
             **isis,
             self._vrf_key: {
-                manufacturer.getRoutingInstanceName(): {
+                manufacturer.getManagementVRFName(): {
                     "description": self._mgmt_vrf_name,
                 }
             },
@@ -123,10 +123,10 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor, TVRFHelpers):
         ).get()
         return {
             self._vrf_key: {
-                manufacturer.getRoutingInstanceName(): {
+                manufacturer.getManagementVRFName(): {
                     "routing_options": {
                         "rib": {
-                            f"{manufacturer.getRoutingInstanceName()}.inet.0": {
+                            f"{manufacturer.getManagementVRFName()}.inet.0": {
                                 "static": {
                                     "0.0.0.0/0": {
                                         "next_hop": str(

--- a/cosmo/routervisitor.py
+++ b/cosmo/routervisitor.py
@@ -60,7 +60,9 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor, TVRFHelpers):
         self.l2vpn_validator = RouterL2VPNValidatorVisitor(
             loopbacks=loopbacks, asn=asn, cosmo_config=self._cosmo_config
         )
-        self.bgpcpe_exporter = RouterBgpCpeExporterVisitor()
+        self.bgpcpe_exporter = RouterBgpCpeExporterVisitor(
+            cosmo_config=self._cosmo_config
+        )
         self.loopbacks = loopbacks
         self.allow_private_ips = features.featureIsEnabled(
             "allow-private-ips-default-vrf"
@@ -123,25 +125,22 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor, TVRFHelpers):
         manufacturer = ManufacturerFactoryFromDevice(
             o.getParent(DeviceType), self._cosmo_config
         ).get()
-        return {
-            self._vrf_key: {
-                manufacturer.getManagementVRFName(): {
-                    "routing_options": {
-                        "rib": {
-                            f"{manufacturer.getManagementVRFName()}.inet.0": {
-                                "static": {
-                                    "0.0.0.0/0": {
-                                        "next_hop": str(
-                                            o.getIPInterfaceObject().network[1]
-                                        ),
-                                    }
-                                }
+        return manufacturer.spitRoutingOptionsPathWith(
+            manufacturer.getManagementVRFName(),
+            {
+                "rib": {
+                    manufacturer.getRibTableNameFor(
+                        manufacturer.getManagementVRFName(), af=4
+                    ): {
+                        "static": {
+                            "0.0.0.0/0": {
+                                "next_hop": str(o.getIPInterfaceObject().network[1]),
                             }
                         }
                     }
                 }
-            }
-        }
+            },
+        )
 
     @accept.register
     def _(self, o: IPAddressType):
@@ -383,6 +382,10 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor, TVRFHelpers):
     def _(self, o: VRFType):
         parent_device = o.getParent(DeviceType)
         parent_interface = o.getParent(InterfaceType)
+        manufacturer = ManufacturerFactoryFromDevice(
+            parent_device, self._cosmo_config
+        ).get()
+
         if not parent_interface.isSubInterface():
             return  # guard: do not process root interface
 
@@ -398,25 +401,24 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor, TVRFHelpers):
         default_targets = [self.assembleRT(o.getID())] if not o.isMgmtVRF() else []
         import_targets = [target.getName() for target in o.getImportTargets()]
         export_targets = [target.getName() for target in o.getExportTargets()]
-        return {
-            self._vrf_key: {
-                o.getName(): {
-                    "interfaces": [parent_interface.getName()],
-                    "description": o.getDescription(),
-                    "instance_type": "vrf",
-                    "route_distinguisher": rd,
-                    "import_targets": (
-                        import_targets if import_targets else default_targets
-                    ),
-                    "export_targets": (
-                        export_targets if export_targets else default_targets
-                    ),
-                    "routing_options": {
-                        # should always have this key present
-                    },
-                }
-            }
-        }
+        return manufacturer.spitVRFPathWith(
+            o,
+            {
+                "interfaces": [parent_interface.getName()],
+                "description": o.getDescription(),
+                "instance_type": "vrf",
+                "route_distinguisher": rd,
+                "import_targets": (
+                    import_targets if import_targets else default_targets
+                ),
+                "export_targets": (
+                    export_targets if export_targets else default_targets
+                ),
+                "routing_options": {
+                    # should always have this key present
+                },
+            },
+        )
 
     @staticmethod
     def processStaticRouteCommon(o: CosmoStaticRouteType, m: AbstractManufacturer):

--- a/cosmo/routervisitor.py
+++ b/cosmo/routervisitor.py
@@ -5,6 +5,7 @@ from multimethod import multimethod as singledispatchmethod
 
 import deepmerge
 
+from cosmo.config.cosmo_config import CosmoConfig
 from cosmo.autodesc import AbstractComposableAutoDescription
 from cosmo.log import warn
 from cosmo.abstractroutervisitor import AbstractRouterExporterVisitor
@@ -46,6 +47,7 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor, TVRFHelpers):
         self,
         loopbacks: LoopbackHelper,
         asn: int,
+        cosmo_config: CosmoConfig,
         *args,
         **kwargs,
     ):
@@ -59,6 +61,7 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor, TVRFHelpers):
             "allow-private-ips-default-vrf"
         )
         self.asn = asn
+        self._cosmo_config = cosmo_config
 
     def getASN(self) -> int:
         return self.asn
@@ -83,7 +86,7 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor, TVRFHelpers):
     def _(self, o: DeviceType):
         if not o.isCompositeRoot():  # not root, do not process!
             return
-        manufacturer = ManufacturerFactoryFromDevice(o).get()
+        manufacturer = ManufacturerFactoryFromDevice(o, self._cosmo_config).get()
         isis = {}
         if isis_system_id := o.getISISIdentifier():
             isis["isis"] = {"system_id": isis_system_id}
@@ -115,7 +118,9 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor, TVRFHelpers):
         }
 
     def processMgmtInterfaceIPAddress(self, o: IPAddressType):
-        manufacturer = ManufacturerFactoryFromDevice(o.getParent(DeviceType)).get()
+        manufacturer = ManufacturerFactoryFromDevice(
+            o.getParent(DeviceType), self._cosmo_config
+        ).get()
         return {
             self._vrf_key: {
                 manufacturer.getRoutingInstanceName(): {
@@ -142,7 +147,9 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor, TVRFHelpers):
             return
         if not o.getParent(InterfaceType).isCurrentDeviceInterface():
             return
-        manufacturer = ManufacturerFactoryFromDevice(o.getParent(DeviceType)).get()
+        manufacturer = ManufacturerFactoryFromDevice(
+            o.getParent(DeviceType), self._cosmo_config
+        ).get()
         optional_attrs = {}
         parent_interface = o.getParent(InterfaceType)
         if not parent_interface.isSubInterface():
@@ -445,6 +452,7 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor, TVRFHelpers):
             }
         }
 
+    # TODO: fix VRF
     @accept.register
     def _(self, o: CosmoStaticRouteType):
         vrf_object = o.getVRF()
@@ -456,10 +464,10 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor, TVRFHelpers):
                 }
             }
         else:
-            return {
-                # device-wide static route
-                **self.processStaticRouteCommon(o)
-            }
+            raise StaticRouteSerializationError(
+                f"Static route {o.getName()} is missing a VRF. VRFs are mandatory for static routes.",
+                on=o,
+            )
 
     @accept.register
     def _(self, o: CosmoIPPoolType):
@@ -649,7 +657,9 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor, TVRFHelpers):
         }
 
     def processCoreTag(self, o: TagType):
-        manufacturer = ManufacturerFactoryFromDevice(o.getParent(DeviceType)).get()
+        manufacturer = ManufacturerFactoryFromDevice(
+            o.getParent(DeviceType), self._cosmo_config
+        ).get()
 
         interface = o.getParent(InterfaceType)
         parent_interface = head(

--- a/cosmo/routervisitor.py
+++ b/cosmo/routervisitor.py
@@ -18,7 +18,7 @@ from cosmo.common import (
 )
 from cosmo.loopbacks import LoopbackHelper
 from cosmo.vrfhelper import TVRFHelpers
-from cosmo.manufacturers import ManufacturerFactoryFromDevice
+from cosmo.manufacturers import ManufacturerFactoryFromDevice, AbstractManufacturer
 from cosmo.routerbgpcpevisitor import RouterBgpCpeExporterVisitor
 from cosmo.features import features
 from cosmo.routerl2vpnvisitor import (
@@ -415,9 +415,8 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor, TVRFHelpers):
         }
 
     @staticmethod
-    def processStaticRouteCommon(o: CosmoStaticRouteType):
+    def processStaticRouteCommon(o: CosmoStaticRouteType, m: AbstractManufacturer):
         next_hop = None
-        table = str()
         next_hop_ipaddr_object = o.getNextHop()
         interface_object = o.getInterface()
         vrf_object = o.getVRF()
@@ -426,41 +425,35 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor, TVRFHelpers):
         elif isinstance(interface_object, InterfaceType):
             next_hop = interface_object.getName()
         if isinstance(vrf_object, VRFType):
-            if o.getPrefixFamily() == 4:
-                table = f"{vrf_object.getName()}.inet.0"
-            elif o.getPrefixFamily() == 6:
-                table = f"{vrf_object.getName()}.inet6.0"
-            else:
-                raise StaticRouteSerializationError(
-                    f"Cannot find associated VRF for {o}! Please check Netbox data."
-                )
+            table = m.getRibTableNameFor(vrf_object, o.getPrefixFamily())
+        else:
+            raise StaticRouteSerializationError(
+                f"Cannot find associated VRF for {o}! Please check Netbox data."
+            )
         return {
-            "routing_options": {
-                "rib": {
-                    table: {
-                        "static": {
-                            o.getPrefix(): {
-                                "next_hop": next_hop,
-                                "resolve_direct": True,
-                            }
-                            | ({"metric": o.getMetric()} if o.getMetric() else {})
+            "rib": {
+                table: {
+                    "static": {
+                        o.getPrefix(): {
+                            "next_hop": next_hop,
+                            "resolve_direct": True,
                         }
+                        | ({"metric": o.getMetric()} if o.getMetric() else {})
                     }
                 }
             }
         }
 
-    # TODO: fix VRF
     @accept.register
     def _(self, o: CosmoStaticRouteType):
         vrf_object = o.getVRF()
+        manufacturer = ManufacturerFactoryFromDevice(
+            o.getParent(DeviceType), self._cosmo_config
+        ).get()
         if isinstance(vrf_object, VRFType):
-            return {
-                # vrf-wide static route
-                self._vrf_key: {
-                    vrf_object.getName(): {**self.processStaticRouteCommon(o)}
-                }
-            }
+            return manufacturer.spitRoutingOptionsPathWith(
+                vrf_object, self.processStaticRouteCommon(o, manufacturer)
+            )
         else:
             raise StaticRouteSerializationError(
                 f"Static route {o.getName()} is missing a VRF. VRFs are mandatory for static routes.",

--- a/cosmo/serializer.py
+++ b/cosmo/serializer.py
@@ -69,13 +69,12 @@ class AbstractSerializer(metaclass=ABCMeta):
 
 
 class RouterSerializer(AbstractSerializer):
-    def __init__(self, device, l2vpn_list, loopbacks, asn, cosmo_config):
+    def __init__(self, device, l2vpn_list, loopbacks, cosmo_config):
         super().__init__(device)
         self.l2vpn_list = l2vpn_list
         self.device["l2vpn_list"] = self.l2vpn_list
         self.device = DeviceType(self.device)
         self.loopbacks = loopbacks
-        self.asn = asn
         self.cosmo_config = cosmo_config
 
         self.l2vpns = {}
@@ -89,9 +88,7 @@ class RouterSerializer(AbstractSerializer):
         }
         loopback_helper = LoopbackHelper(loopbacks)
         self.router_device_export_visitor = RouterDeviceExporterVisitor(
-            loopbacks=loopback_helper,
-            asn=self.asn,
-            cosmo_config=cosmo_config,
+            loopbacks=loopback_helper, cosmo_config=cosmo_config
         )
         if self.allow_private_ips:
             self.router_device_export_visitor.allowPrivateIPs()

--- a/cosmo/serializer.py
+++ b/cosmo/serializer.py
@@ -69,13 +69,14 @@ class AbstractSerializer(metaclass=ABCMeta):
 
 
 class RouterSerializer(AbstractSerializer):
-    def __init__(self, device, l2vpn_list, loopbacks, asn):
+    def __init__(self, device, l2vpn_list, loopbacks, asn, cosmo_config):
         super().__init__(device)
         self.l2vpn_list = l2vpn_list
         self.device["l2vpn_list"] = self.l2vpn_list
         self.device = DeviceType(self.device)
         self.loopbacks = loopbacks
         self.asn = asn
+        self.cosmo_config = cosmo_config
 
         self.l2vpns = {}
         self.l3vpns = {}
@@ -90,6 +91,7 @@ class RouterSerializer(AbstractSerializer):
         self.router_device_export_visitor = RouterDeviceExporterVisitor(
             loopbacks=loopback_helper,
             asn=self.asn,
+            cosmo_config=cosmo_config,
         )
         if self.allow_private_ips:
             self.router_device_export_visitor.allowPrivateIPs()
@@ -113,8 +115,12 @@ class RouterSerializer(AbstractSerializer):
 
 
 class SwitchSerializer(AbstractSerializer):
+    def __init__(self, device, cosmo_config):
+        super().__init__(device)
+        self._cosmo_config = cosmo_config
+
     def switchExport(self, device_stub: CosmoOutputType, value: AbstractNetboxType):
-        new = SwitchDeviceExporterVisitor().accept(value)
+        new = SwitchDeviceExporterVisitor(cosmo_config=self._cosmo_config).accept(value)
         if new:
             device_stub = self.getMerger().merge(device_stub, new)
 

--- a/cosmo/switchvisitor.py
+++ b/cosmo/switchvisitor.py
@@ -1,6 +1,8 @@
 import ipaddress
+
 from multimethod import multimethod as singledispatchmethod
 
+from cosmo.config.cosmo_config import CosmoConfig
 from cosmo.autodesc import AbstractComposableAutoDescription
 from cosmo.common import APP_NAME
 from cosmo.log import warn
@@ -18,13 +20,18 @@ from cosmo.visitors import AbstractNoopNetboxTypesVisitor
 class SwitchDeviceExporterVisitor(AbstractNoopNetboxTypesVisitor):
     _interfaces_key = "cumulus__device_interfaces"
 
+    def __init__(self, cosmo_config: CosmoConfig):
+        self._cosmo_config = cosmo_config
+
     @singledispatchmethod
     def accept(self, o):
         return super().accept(o)
 
     @accept.register
     def _(self, o: IPAddressType):
-        manufacturer = ManufacturerFactoryFromDevice(o.getParent(DeviceType)).get()
+        manufacturer = ManufacturerFactoryFromDevice(
+            o.getParent(DeviceType), self._cosmo_config
+        ).get()
         if not o.hasParentAboveWithType(InterfaceType):
             return
         parent_interface = o.getParent(InterfaceType)
@@ -84,9 +91,10 @@ class SwitchDeviceExporterVisitor(AbstractNoopNetboxTypesVisitor):
             ]
         return ret
 
-    @staticmethod
-    def processInterfaceCommon(o: InterfaceType):
-        manufacturer = ManufacturerFactoryFromDevice(o.getParent(DeviceType)).get()
+    def processInterfaceCommon(self, o: InterfaceType):
+        manufacturer = ManufacturerFactoryFromDevice(
+            o.getParent(DeviceType), self._cosmo_config
+        ).get()
         description = {"description": o.getDescription()} if o.hasDescription() else {}
         bpdu_filter = (
             {"bpdufilter": True} if not manufacturer.isManagementInterface(o) else {}

--- a/cosmo/tests/cosmo.devgen_ansible.yml
+++ b/cosmo/tests/cosmo.devgen_ansible.yml
@@ -1,5 +1,5 @@
 output_format: "ansible"
-global_vrf: default
+global_vrf: global
 asn: 65542
 devices:
   router:

--- a/cosmo/tests/cosmo.devgen_ansible.yml
+++ b/cosmo/tests/cosmo.devgen_ansible.yml
@@ -1,4 +1,5 @@
 output_format: "ansible"
+global_vrf: default
 asn: 65542
 devices:
   router:

--- a/cosmo/tests/cosmo.devgen_nix.yml
+++ b/cosmo/tests/cosmo.devgen_nix.yml
@@ -1,5 +1,6 @@
 output_format: "nix"
 asn: 65542
+global_vrf: default
 devices:
   router:
     - "TEST0001"

--- a/cosmo/tests/cosmo.devgen_nix.yml
+++ b/cosmo/tests/cosmo.devgen_nix.yml
@@ -1,6 +1,6 @@
 output_format: "nix"
 asn: 65542
-global_vrf: default
+global_vrf: global
 devices:
   router:
     - "TEST0001"

--- a/cosmo/tests/cosmo.wrong.yml
+++ b/cosmo/tests/cosmo.wrong.yml
@@ -1,5 +1,6 @@
 output_format: "unknown"
 asn: -732
+global_vrf: YES
 devices:
   router:
     TEST0001: NO

--- a/cosmo/tests/test_case_vrf_staticroute.yaml
+++ b/cosmo/tests/test_case_vrf_staticroute.yaml
@@ -118,6 +118,39 @@ device_list:
       name: L3VPN-TEST
       rd: null
       __typename: VRFType
+  - custom_fields:
+      bpdufilter: false
+      inner_tag: null
+      ipv6_ra: false
+      outer_tag: null
+      storm_control__broadcast: null
+      storm_control__multicast: null
+      storm_control__unknown_unicast: null
+    __typename: InterfaceType
+    description: ''
+    enabled: true
+    id: '2005'
+    ip_addresses: []
+    lag: null
+    mac_address: null
+    mode: ACCESS
+    mtu: 1500
+    name: et-0/0/2.3
+    tagged_vlans: []
+    type: VIRTUAL
+    untagged_vlan:
+      __typename: VLANType
+      id: '1003'
+      name: ''
+      vid: 3
+    vrf:
+      description: Test Global VRF
+      export_targets: []
+      id: '407'
+      import_targets: []
+      name: global
+      rd: null
+      __typename: VRFType
   name: TEST0001
   platform:
     __typename: PlatformType
@@ -151,6 +184,17 @@ device_list:
       prefix: fd98::1/128
     vrf:
       name: L3VPN-TEST
+  - interface:
+      name: et-0/0/2.3
+    next_hop: null
+    __typename: CosmoStaticRouteType
+    metric: 100
+    prefix:
+      family:
+        value: 4
+      prefix: 10.0.0.0/8
+    vrf:
+      name: global
 l2vpn_list: []
 loopbacks:
   TEST0001:

--- a/cosmo/tests/test_serializer.py
+++ b/cosmo/tests/test_serializer.py
@@ -117,7 +117,7 @@ def test_router_platforms(mock_cosmo_config_fixture, mock_global_vrf, mock_l3vpn
     juniper_manufacturer = ManufacturerFactoryFromDevice(
         DeviceType(juniper_s.device), mock_cosmo_config_fixture
     ).get()
-    assert juniper_manufacturer.getRoutingInstanceName() == "mgmt_junos"
+    assert juniper_manufacturer.getManagementVRFName() == "mgmt_junos"
     assert juniper_manufacturer.myManufacturerSlug() == "juniper"
     assert (
         juniper_manufacturer.spitVRFPathWith(mock_global_vrf, {})
@@ -134,7 +134,7 @@ def test_router_platforms(mock_cosmo_config_fixture, mock_global_vrf, mock_l3vpn
     rtbrick_manufacturer = ManufacturerFactoryFromDevice(
         DeviceType(rtbrick_s.device), mock_cosmo_config_fixture
     ).get()
-    assert rtbrick_manufacturer.getRoutingInstanceName() == "mgmt"
+    assert rtbrick_manufacturer.getManagementVRFName() == "mgmt"
     assert rtbrick_manufacturer.myManufacturerSlug() == "rtbrick"
     assert rtbrick_manufacturer._spitDefaultVRFPathWith({}) == {
         "routing_instances": {"default": {}}

--- a/cosmo/tests/test_serializer.py
+++ b/cosmo/tests/test_serializer.py
@@ -67,7 +67,6 @@ def get_router_s_from_path(path):
             device=device,
             l2vpn_list=test_data["l2vpn_list"],
             loopbacks=test_data.get("loopbacks", {}),
-            asn=65542,
             cosmo_config=mock_cosmo_config(),
         ).allowPrivateIPs()
         return_list.append(rs)
@@ -183,7 +182,6 @@ def test_l2vpn_errors(capsys, mock_cosmo_config_fixture):
         device=y["device_list"][0],
         l2vpn_list=y["l2vpn_list"],
         loopbacks=y["loopbacks"],
-        asn=65542,
         cosmo_config=mock_cosmo_config_fixture,
     ).serialize()
 

--- a/cosmo/tests/test_serializer.py
+++ b/cosmo/tests/test_serializer.py
@@ -114,6 +114,7 @@ def get_switch_sd_from_path(path):
 def test_router_platforms(mock_cosmo_config_fixture, mock_global_vrf, mock_l3vpn_vrf):
 
     [juniper_s] = get_router_s_from_path("./test_case_2.yaml")
+    [juniper_sd] = get_router_sd_from_path("./test_case_2.yaml")
     juniper_manufacturer = ManufacturerFactoryFromDevice(
         DeviceType(juniper_s.device), mock_cosmo_config_fixture
     ).get()
@@ -126,19 +127,35 @@ def test_router_platforms(mock_cosmo_config_fixture, mock_global_vrf, mock_l3vpn
     )
     assert (
         juniper_manufacturer.spitVRFPathWith(mock_l3vpn_vrf, {})
-        == juniper_manufacturer._spitOtherVRFPathWith(mock_l3vpn_vrf, {})
+        == juniper_manufacturer._spitOtherVRFPathWith(mock_l3vpn_vrf.getName(), {})
         == {"routing_instances": {mock_l3vpn_vrf.getName(): {}}}
+    )
+    assert (
+        juniper_sd["routing_instances"]["mgmt_junos"]["description"]
+        == "MGMT-ROUTING-INSTANCE"
     )
 
     [rtbrick_s] = get_router_s_from_path("./test_case_l3vpn.yml")
+    [rtbrick_sd] = get_router_sd_from_path("./test_case_l3vpn.yml")
     rtbrick_manufacturer = ManufacturerFactoryFromDevice(
         DeviceType(rtbrick_s.device), mock_cosmo_config_fixture
     ).get()
     assert rtbrick_manufacturer.getManagementVRFName() == "mgmt"
     assert rtbrick_manufacturer.myManufacturerSlug() == "rtbrick"
-    assert rtbrick_manufacturer._spitDefaultVRFPathWith({}) == {
-        "routing_instances": {"default": {}}
-    }
+    assert (
+        rtbrick_manufacturer.spitVRFPathWith(mock_global_vrf, {})
+        == rtbrick_manufacturer._spitDefaultVRFPathWith({})
+        == {"routing_instances": {"default": {}}}
+    )
+    assert (
+        rtbrick_manufacturer.spitVRFPathWith(mock_l3vpn_vrf, {})
+        == rtbrick_manufacturer._spitOtherVRFPathWith(mock_l3vpn_vrf.getName(), {})
+        == {"routing_instances": {mock_l3vpn_vrf.getName(): {}}}
+    )
+    assert (
+        rtbrick_sd["routing_instances"]["mgmt"]["description"]
+        == "MGMT-ROUTING-INSTANCE"
+    )
 
     with pytest.raises(Exception):
         s = get_router_s_from_path("./test_case_vendor_unknown.yaml")

--- a/cosmo/tests/test_serializer.py
+++ b/cosmo/tests/test_serializer.py
@@ -123,13 +123,19 @@ def test_router_platforms(mock_cosmo_config_fixture, mock_global_vrf, mock_l3vpn
     assert (
         juniper_manufacturer.spitVRFPathWith(mock_global_vrf, {})
         == juniper_manufacturer._spitDefaultVRFPathWith({})
-        == {"routing_options": {}}
+        == {}
     )
     assert (
         juniper_manufacturer.spitVRFPathWith(mock_l3vpn_vrf, {})
         == juniper_manufacturer._spitOtherVRFPathWith(mock_l3vpn_vrf.getName(), {})
         == {"routing_instances": {mock_l3vpn_vrf.getName(): {}}}
     )
+    assert juniper_manufacturer.spitRoutingOptionsPathWith(mock_global_vrf, {}) == {
+        "routing_options": {}
+    }
+    assert juniper_manufacturer.spitRoutingOptionsPathWith(mock_l3vpn_vrf, {}) == {
+        "routing_instances": {mock_l3vpn_vrf.getName(): {"routing_options": {}}}
+    }
     assert (
         juniper_sd["routing_instances"]["mgmt_junos"]["description"]
         == "MGMT-ROUTING-INSTANCE"
@@ -152,6 +158,12 @@ def test_router_platforms(mock_cosmo_config_fixture, mock_global_vrf, mock_l3vpn
         == rtbrick_manufacturer._spitOtherVRFPathWith(mock_l3vpn_vrf.getName(), {})
         == {"routing_instances": {mock_l3vpn_vrf.getName(): {}}}
     )
+    assert rtbrick_manufacturer.spitRoutingOptionsPathWith(mock_global_vrf, {}) == {
+        "routing_instances": {"default": {"routing_options": {}}}
+    }
+    assert rtbrick_manufacturer.spitRoutingOptionsPathWith(mock_l3vpn_vrf, {}) == {
+        "routing_instances": {mock_l3vpn_vrf.getName(): {"routing_options": {}}}
+    }
     assert (
         rtbrick_sd["routing_instances"]["mgmt"]["description"]
         == "MGMT-ROUTING-INSTANCE"
@@ -426,6 +438,24 @@ def test_router_vrf_rib():
     [sd] = get_router_sd_from_path("./test_case_vrf_staticroute.yaml")
 
     assert "routing_instances" in sd
+    assert "routing_options" in sd
+    assert "rib" in sd["routing_options"]
+    assert "inet.0" in sd["routing_options"]["rib"]
+    assert "static" in sd["routing_options"]["rib"]["inet.0"]
+    assert "10.0.0.0/8" in sd["routing_options"]["rib"]["inet.0"]["static"]
+    assert "next_hop" in sd["routing_options"]["rib"]["inet.0"]["static"]["10.0.0.0/8"]
+    assert (
+        sd["routing_options"]["rib"]["inet.0"]["static"]["10.0.0.0/8"]["next_hop"]
+        == "et-0/0/2.3"
+    )
+    assert (
+        sd["routing_options"]["rib"]["inet.0"]["static"]["10.0.0.0/8"]["resolve_direct"]
+        == True
+    )
+    assert (
+        sd["routing_options"]["rib"]["inet.0"]["static"]["10.0.0.0/8"]["metric"] == 100
+    )
+
     assert "L3VPN-TEST" in sd["routing_instances"]
     assert "routing_options" in sd["routing_instances"]["L3VPN-TEST"]
     assert "rib" in sd["routing_instances"]["L3VPN-TEST"]["routing_options"]

--- a/cosmo/tests/test_serializer.py
+++ b/cosmo/tests/test_serializer.py
@@ -126,7 +126,7 @@ def test_router_platforms(mock_cosmo_config_fixture, mock_global_vrf, mock_l3vpn
     )
     assert (
         juniper_manufacturer.spitVRFPathWith(mock_l3vpn_vrf, {})
-        == juniper_manufacturer._spitOtherVRFPathWith(mock_l3vpn_vrf.getName(), {})
+        == juniper_manufacturer._spitOtherVRFPathWith(mock_l3vpn_vrf, {})
         == {"routing_instances": {mock_l3vpn_vrf.getName(): {}}}
     )
 
@@ -136,16 +136,9 @@ def test_router_platforms(mock_cosmo_config_fixture, mock_global_vrf, mock_l3vpn
     ).get()
     assert rtbrick_manufacturer.getRoutingInstanceName() == "mgmt"
     assert rtbrick_manufacturer.myManufacturerSlug() == "rtbrick"
-    assert (
-        rtbrick_manufacturer.spitVRFPathWith(mock_global_vrf, {})
-        == rtbrick_manufacturer._spitDefaultVRFPathWith({})
-        == {"routing_instances": {"default": {}}}
-    )
-    assert (
-        rtbrick_manufacturer.spitVRFPathWith(mock_l3vpn_vrf, {})
-        == rtbrick_manufacturer._spitOtherVRFPathWith(mock_l3vpn_vrf.getName(), {})
-        == {"routing_instances": {mock_l3vpn_vrf.getName(): {}}}
-    )
+    assert rtbrick_manufacturer._spitDefaultVRFPathWith({}) == {
+        "routing_instances": {"default": {}}
+    }
 
     with pytest.raises(Exception):
         s = get_router_s_from_path("./test_case_vendor_unknown.yaml")

--- a/cosmo/tests/test_serializer.py
+++ b/cosmo/tests/test_serializer.py
@@ -5,13 +5,49 @@ import pytest
 import copy
 
 from cosmo.common import DeviceSerializationError
+from cosmo.config.cosmo_config import CosmoConfig
 from cosmo.features import with_feature, features, without_feature
 from cosmo.manufacturers import ManufacturerFactoryFromDevice
-from cosmo.netbox_types import DeviceType
+from cosmo.netbox_types import DeviceType, VRFType
 
 from coverage.html import os
 
 from cosmo.serializer import RouterSerializer, SwitchSerializer
+
+
+def mock_cosmo_config():
+    return CosmoConfig(f"cosmo/tests/cosmo.devgen_ansible.yml")
+
+
+@pytest.fixture
+def mock_cosmo_config_fixture():
+    return CosmoConfig(f"cosmo/tests/cosmo.devgen_ansible.yml")
+
+
+@pytest.fixture
+def mock_global_vrf(mock_cosmo_config_fixture):
+    return VRFType(
+        {
+            "description": "default vrf",
+            "name": mock_cosmo_config_fixture.getGlobalVRFName(),
+            "import_targets": {},
+            "export_targets": {},
+            "rd": "",
+        }
+    )
+
+
+@pytest.fixture
+def mock_l3vpn_vrf():
+    return VRFType(
+        {
+            "description": "",
+            "name": "L3VPN-NTD",
+            "import_targets": {},
+            "export_targets": {},
+            "rd": "409",
+        }
+    )
 
 
 def _yaml_load(path):
@@ -32,6 +68,7 @@ def get_router_s_from_path(path):
             l2vpn_list=test_data["l2vpn_list"],
             loopbacks=test_data.get("loopbacks", {}),
             asn=65542,
+            cosmo_config=mock_cosmo_config(),
         ).allowPrivateIPs()
         return_list.append(rs)
 
@@ -40,7 +77,10 @@ def get_router_s_from_path(path):
 
 def get_switch_s_from_path(path):
     test_data = _yaml_load(path)
-    return [SwitchSerializer(device=device) for device in test_data["device_list"]]
+    return [
+        SwitchSerializer(device=device, cosmo_config=mock_cosmo_config())
+        for device in test_data["device_list"]
+    ]
 
 
 def get_router_sd_from_path(path):
@@ -71,21 +111,41 @@ def get_switch_sd_from_path(path):
     return return_switches
 
 
-def test_router_platforms():
+def test_router_platforms(mock_cosmo_config_fixture, mock_global_vrf, mock_l3vpn_vrf):
 
     [juniper_s] = get_router_s_from_path("./test_case_2.yaml")
     juniper_manufacturer = ManufacturerFactoryFromDevice(
-        DeviceType(juniper_s.device)
+        DeviceType(juniper_s.device), mock_cosmo_config_fixture
     ).get()
     assert juniper_manufacturer.getRoutingInstanceName() == "mgmt_junos"
     assert juniper_manufacturer.myManufacturerSlug() == "juniper"
+    assert (
+        juniper_manufacturer.spitVRFPathWith(mock_global_vrf, {})
+        == juniper_manufacturer._spitDefaultVRFPathWith({})
+        == {"routing_options": {}}
+    )
+    assert (
+        juniper_manufacturer.spitVRFPathWith(mock_l3vpn_vrf, {})
+        == juniper_manufacturer._spitOtherVRFPathWith(mock_l3vpn_vrf.getName(), {})
+        == {"routing_instances": {mock_l3vpn_vrf.getName(): {}}}
+    )
 
     [rtbrick_s] = get_router_s_from_path("./test_case_l3vpn.yml")
-    juniper_manufacturer = ManufacturerFactoryFromDevice(
-        DeviceType(rtbrick_s.device)
+    rtbrick_manufacturer = ManufacturerFactoryFromDevice(
+        DeviceType(rtbrick_s.device), mock_cosmo_config_fixture
     ).get()
-    assert juniper_manufacturer.getRoutingInstanceName() == "mgmt"
-    assert juniper_manufacturer.myManufacturerSlug() == "rtbrick"
+    assert rtbrick_manufacturer.getRoutingInstanceName() == "mgmt"
+    assert rtbrick_manufacturer.myManufacturerSlug() == "rtbrick"
+    assert (
+        rtbrick_manufacturer.spitVRFPathWith(mock_global_vrf, {})
+        == rtbrick_manufacturer._spitDefaultVRFPathWith({})
+        == {"routing_instances": {"default": {}}}
+    )
+    assert (
+        rtbrick_manufacturer.spitVRFPathWith(mock_l3vpn_vrf, {})
+        == rtbrick_manufacturer._spitOtherVRFPathWith(mock_l3vpn_vrf.getName(), {})
+        == {"routing_instances": {mock_l3vpn_vrf.getName(): {}}}
+    )
 
     with pytest.raises(Exception):
         s = get_router_s_from_path("./test_case_vendor_unknown.yaml")
@@ -96,12 +156,13 @@ def test_router_platforms():
         s.serialize()
 
 
-def test_l2vpn_errors(capsys):
+def test_l2vpn_errors(capsys, mock_cosmo_config_fixture):
     serialize = lambda y: RouterSerializer(
         device=y["device_list"][0],
         l2vpn_list=y["l2vpn_list"],
         loopbacks=y["loopbacks"],
         asn=65542,
+        cosmo_config=mock_cosmo_config_fixture,
     ).serialize()
 
     template = _yaml_load("./test_case_l2x_err_template.yaml")


### PR DESCRIPTION
fixes #89 

TODO:
- [x] config file default VRF name parameter
      in json schema spec and settings
- [x] remove logic branch where field is expected
      to be nullable and/or fail on null ("illegal" value)
- [x] by-manufacturer default VRF path "spit with"
      (same as interface ?) should be moved in
      manufacturer in any case
  - [x] routing_options for ansible_junos
  - [x] routing_instances.default for rtbrick
- [x] update / fix test cases, 1 by manufacturer
- [x] rebase after #108 is merged
