### PR TITLE
evpn vpws: filter by interface id instead of device

### DIFF
--- a/cosmo/l2vpnhelpertypes.py
+++ b/cosmo/l2vpnhelpertypes.py
@@ -373,10 +373,7 @@ class AbstractVPWSEVPNVPWSVpnTypeCommon(
         # find local end
         local = next(
             filter(
-                lambda i: (
-                    isinstance(i, InterfaceType)
-                    and i.getAssociatedDevice() == parent_device
-                ),
+                lambda i: (isinstance(i, InterfaceType) and i == o),
                 parent_l2vpn.getTerminations(),
             )
         )


### PR DESCRIPTION
This enables to have both terminations on the same device