### PR TITLE
fix: add jsonschema nix package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764522689,
-        "narHash": "sha256-SqUuBFjhl/kpDiVaKLQBoD8TLD+/cTUzzgVFoaHrkqY=",
+        "lastModified": 1773646010,
+        "narHash": "sha256-iYrs97hS7p5u4lQzuNWzuALGIOdkPXvjz7bviiBjUu8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8bb5646e0bed5dbd3ab08c7a7cc15b75ab4e1d0f",
+        "rev": "5b2c2d84341b2afb5647081c1386a80d7a8d8605",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "cosmo - ???";
 
   inputs.flake-utils.url = "github:numtide/flake-utils";
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
   outputs = { self, nixpkgs, flake-utils }:
     {

--- a/package.nix
+++ b/package.nix
@@ -7,6 +7,7 @@
   deepmerge,
   termcolor,
   multimethod,
+  jsonschema,
   cosmo-version,
   pytestCheckHook,
   pytest-mock,
@@ -46,6 +47,26 @@ buildPythonApplication rec {
           inherit pname version;
           hash = "sha256-gHEE/KSLe8TMQmDL8jXidpSBgerRX8ZTU4ldOioL7MA=";
         };
+      }
+    ) {})
+    (callPackage (
+      { buildPythonPackage, fetchPypi, setuptools, referencing }:
+      buildPythonPackage rec {
+        pname = "types-jsonschema";
+        version = "4.26.0.20260202";
+
+        src = fetchPypi {
+          inherit version;
+          pname = "types_jsonschema";
+          hash = "sha256-KYMbqkMIhlqa7FR6YXl6BvwVKw2sjd3VMeAC8yJlywc=";
+        };
+
+        format = "pyproject";
+        build-system = [ setuptools ];
+
+        dependencies = [
+          referencing
+        ];
       }
     ) {})
   ];


### PR DESCRIPTION
the flake bump to unstable is needed, since the current version of jsonschema in nixos-25.11 is 4.25.0, while we need 4.26.0