### PR TITLE
feat: Add tag to disable traffic sampling

### DIFF
--- a/cosmo/routervisitor.py
+++ b/cosmo/routervisitor.py
@@ -204,6 +204,7 @@ class RouterDeviceExporterVisitor(AbstractRouterExporterVisitor, TVRFHelpers):
             parent_interface.getVRF() == None
             and not manufacturer.isManagementInterface(parent_interface)
             and not parent_interface.isLoopbackOrParentIsLoopback()
+            and not any([t.getTagName() == "disable_sampling" for t in parent_interface.getTags()])
         ):
             sampling = {"sampling": True}
         return {


### PR DESCRIPTION
We need a tag to disable traffic sampling for specific interfaces. 
Currently its only disabled for loopback and mgmt interfaces as well as interfaces in an VRF. 
Breakout ports dont support sampling on rtbrick which currently throws an error with no way to fix it. 
This gives you the option to disable traffic sampling by adding a tag to the interface.